### PR TITLE
Add template editing and management

### DIFF
--- a/lib/services/database/database-interface.dart
+++ b/lib/services/database/database-interface.dart
@@ -27,6 +27,7 @@ abstract class DatabaseInterface {
   Future<void> deleteRecordById(int? id);
   Future<int> addRecord(Record? record);
   Future<int> addTemplate(Template? template);
+  Future<int> updateTemplate(Template? template);
   Future<void> addRecordsInBatch(List<Record?> records);
   Future<int?> updateRecordById(int? recordId, Record? newRecord);
   Future<DateTime?> getDateTimeFirstRecord();

--- a/lib/services/database/sqlite-database.dart
+++ b/lib/services/database/sqlite-database.dart
@@ -773,4 +773,16 @@ class SqliteDatabase implements DatabaseInterface {
     final db = (await database)!;
     await db.delete("templates", where: "id = ?", whereArgs: [id]);
   }
+
+  @override
+  Future<int> updateTemplate(Template? template) async {
+    final db = (await database)!;
+    var templateMap = template!.toMap();
+    if (templateMap['id'] == null) {
+      templateMap['id'] = template.id;
+    }
+    int updatedRows = await db
+        .update("templates", templateMap, where: "id = ?", whereArgs: [template.id]);
+    return updatedRows;
+  }
 }

--- a/lib/settings/settings-page.dart
+++ b/lib/settings/settings-page.dart
@@ -9,6 +9,7 @@ import 'package:pocket_guard/settings/backup-restore-dialogs.dart';
 import 'package:pocket_guard/settings/feedback-page.dart';
 import 'package:pocket_guard/settings/settings-item.dart';
 import 'package:pocket_guard/tags/tags-page-view.dart';
+import 'package:pocket_guard/template/templates-list.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../i18n.dart';
@@ -69,6 +70,13 @@ class TabSettings extends StatelessWidget {
     await Navigator.push(
       context,
       MaterialPageRoute(builder: (context) => TagsPageView()),
+    );
+  }
+
+  goToTemplatesPage(BuildContext context) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => TemplatesList()),
     );
   }
 
@@ -136,6 +144,15 @@ class TabSettings extends StatelessWidget {
               title: 'Tags'.i18n,
               subtitle: "Manage your existing tags".i18n,
               onPressed: () async => await goToTagsPage(context)),
+          SettingsItem(
+              icon: Icon(
+                Icons.layers,
+                color: Colors.white,
+              ),
+              iconBackgroundColor: Colors.amber.shade600,
+              title: 'Templates'.i18n,
+              subtitle: "Manage your existing templates".i18n,
+              onPressed: () async => await goToTemplatesPage(context)),
           Divider(),
           SettingsItem(
               icon: Icon(

--- a/lib/template/templates-list.dart
+++ b/lib/template/templates-list.dart
@@ -6,6 +6,7 @@ import 'package:pocket_guard/models/category-type.dart';
 import 'package:pocket_guard/models/template.dart';
 import 'package:pocket_guard/services/database/database-interface.dart';
 import 'package:pocket_guard/services/service-config.dart';
+import 'package:pocket_guard/template/template-page.dart';
 
 import '../i18n.dart';
 
@@ -39,9 +40,7 @@ class _TemplatesListState extends State<TemplatesList> {
     });
   }
 
-  @override
-  void initState() {
-    super.initState();
+  void _refreshTemplates() async {
     database
         .getTemplates(widget.passedCategoryType)
         .then(
@@ -55,9 +54,20 @@ class _TemplatesListState extends State<TemplatesList> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    _refreshTemplates();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final isExpense = widget.passedCategoryType == CategoryType.expense;
-    final title = isExpense ? "Expense Templates" : "Income Templates";
+    var title = "";
+    if (widget.passedCategoryType == null) {
+      title = "Templates";
+    } else {
+      final isExpense = widget.passedCategoryType == CategoryType.expense;
+      title = isExpense ? "Expense Templates" : "Income Templates";
+    }
     return Scaffold(
       appBar: AppBar(title: Text(title.i18n)),
       body: Container(
@@ -114,6 +124,18 @@ class _TemplatesListState extends State<TemplatesList> {
       onTap: () async {
         if (widget.returnResult != null && widget.returnResult == true) {
           Navigator.pop(context, template);
+        }
+
+        if (widget.passedCategoryType == null) {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => TemplatePage(passedTemplate: template),
+            ),
+          );
+          setState(() {
+            _refreshTemplates();
+          });
         }
         if (widget.callback != null) widget.callback!();
       },


### PR DESCRIPTION
This commit introduces the ability to edit existing templates and manage all templates from a central location in the settings.

- **Templates**:
  - Implements the ability to edit an existing template.
  - Adds an `updateTemplate` method to the database interface and its SQLite implementation.
  - The `TemplatePage` is now used for both adding and editing templates, with a dynamic title ("Add Template" or "Edit Template").

- **UI/UX**:
  - Adds a new "Templates" option in the main `Settings` page, allowing users to view, manage, and edit all their templates.
  - From the new management screen, tapping a template opens it for editing.
  - After editing a template, the list is automatically refreshed.