### PR TITLE
Use CategoryFactory to cache Category instances

### DIFF
--- a/lib/categories/notifiers/edit_category_provider.dart
+++ b/lib/categories/notifiers/edit_category_provider.dart
@@ -3,6 +3,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:pocket_guard/models/category-icons.dart';
 import 'package:pocket_guard/models/category-type.dart';
 import 'package:pocket_guard/models/category.dart';
+import 'package:pocket_guard/models/category_factory.dart';
 import 'package:pocket_guard/services/database/database-interface.dart';
 
 class EditCategoryProvider extends ChangeNotifier {
@@ -57,7 +58,7 @@ class EditCategoryProvider extends ChangeNotifier {
       _category.categoryType = type ?? CategoryType.expense;
     } else {
       // Clone existing category (assuming you have a copy method or fromMap)
-      _category = Category.fromMap(passed.toMap());
+      _category = CategoryFactory.getOrCreate(passed.toMap());
       _categoryName = passed.name!;
     }
 

--- a/lib/models/category_factory.dart
+++ b/lib/models/category_factory.dart
@@ -13,25 +13,44 @@ class CategoryFactory {
       _cache[key] = Category.fromMap(map);
     } else {
       final existing = _cache[key]!;
-      existing.color = _parseColor(map['color']) ?? existing.color;
-      existing.recordCount = (map['record_count'] != null)
-          ? map['record_count'] as int
-          : existing.recordCount;
-      existing.sortOrder = (map['sort_order'] != null)
-          ? map['sort_order'] as int
-          : existing.sortOrder;
-      existing.isArchived = (map['is_archived'] != null)
-          ? (map['is_archived'] as int) == 1
-          : existing.isArchived;
-      existing.iconCodePoint = map['icon'] ?? existing.iconCodePoint;
-      existing.iconEmoji = map['icon_emoji'] ?? existing.iconEmoji;
-      if (map['last_used'] != null) {
-        existing.lastUsed = DateTime.fromMillisecondsSinceEpoch(
-          map['last_used'] as int,
-        );
+      final lastUsed = map['last_used'] as int?;
+      final lastUsedDateTime = lastUsed != null
+          ? _parseLastTimeUsedDateTime(lastUsed)
+          : null;
+
+      bool shouldUpdateExisting = _shouldUpdate(existing, lastUsedDateTime);
+
+      if (shouldUpdateExisting) {
+        existing.color = _parseColor(map['color']) ?? existing.color;
+        existing.recordCount = (map['record_count'] != null)
+            ? map['record_count'] as int
+            : existing.recordCount;
+        existing.sortOrder = (map['sort_order'] != null)
+            ? map['sort_order'] as int
+            : existing.sortOrder;
+        existing.isArchived = (map['is_archived'] != null)
+            ? (map['is_archived'] as int) == 1
+            : existing.isArchived;
+        existing.iconCodePoint = map['icon'] ?? existing.iconCodePoint;
+        existing.iconEmoji = map['icon_emoji'] ?? existing.iconEmoji;
+        existing.lastUsed = lastUsedDateTime;
       }
     }
     return _cache[key]!;
+  }
+
+  // UPDATE LOGIC:
+  // 1. If the database has a timestamp and memory doesn't.
+  // 2. OR if the database timestamp is newer.
+  static bool _shouldUpdate(Category existing, DateTime? lastUsedDateTime) {
+    return (existing.lastUsed == null && lastUsedDateTime != null) ||
+        (lastUsedDateTime != null &&
+            existing.lastUsed != null &&
+            lastUsedDateTime.isAfter(existing.lastUsed!));
+  }
+
+  static DateTime? _parseLastTimeUsedDateTime(int time) {
+    return DateTime.fromMillisecondsSinceEpoch(time);
   }
 
   static Color? _parseColor(String? serializedColor) {

--- a/lib/models/category_factory.dart
+++ b/lib/models/category_factory.dart
@@ -1,0 +1,18 @@
+import 'package:pocket_guard/models/category.dart';
+
+class CategoryFactory {
+   static final Map<String, Category> _cache = {};
+
+  static Category getOrCreate(Map<String, dynamic> map) {
+    final String name = map['name'] ?? 'Unknown';
+    final int typeIndex = map['category_type'] ?? 0;
+    final String key = "${name}_$typeIndex";
+
+    if (!_cache.containsKey(key)) {
+      _cache[key] = Category.fromMap(map);
+    }
+    return _cache[key]!;
+  }
+
+  static void clear() => _cache.clear();
+}

--- a/lib/models/category_factory.dart
+++ b/lib/models/category_factory.dart
@@ -1,7 +1,8 @@
+import 'package:flutter/cupertino.dart';
 import 'package:pocket_guard/models/category.dart';
 
 class CategoryFactory {
-   static final Map<String, Category> _cache = {};
+  static final Map<String, Category> _cache = {};
 
   static Category getOrCreate(Map<String, dynamic> map) {
     final String name = map['name'] ?? 'Unknown';
@@ -10,8 +11,38 @@ class CategoryFactory {
 
     if (!_cache.containsKey(key)) {
       _cache[key] = Category.fromMap(map);
+    } else {
+      final existing = _cache[key]!;
+      existing.color = _parseColor(map['color']) ?? existing.color;
+      existing.recordCount = (map['record_count'] != null)
+          ? map['record_count'] as int
+          : existing.recordCount;
+      existing.sortOrder = (map['sort_order'] != null)
+          ? map['sort_order'] as int
+          : existing.sortOrder;
+      existing.isArchived = (map['is_archived'] != null)
+          ? (map['is_archived'] as int) == 1
+          : existing.isArchived;
+      existing.iconCodePoint = map['icon'] ?? existing.iconCodePoint;
+      existing.iconEmoji = map['icon_emoji'] ?? existing.iconEmoji;
+      if (map['last_used'] != null) {
+        existing.lastUsed = DateTime.fromMillisecondsSinceEpoch(
+          map['last_used'] as int,
+        );
+      }
     }
     return _cache[key]!;
+  }
+
+  static Color? _parseColor(String? serializedColor) {
+    if (serializedColor == null) return null;
+    List<int> components = serializedColor.split(":").map(int.parse).toList();
+    return Color.fromARGB(
+      components[0],
+      components[1],
+      components[2],
+      components[3],
+    );
   }
 
   static void clear() => _cache.clear();

--- a/lib/services/database/sqlite-database.dart
+++ b/lib/services/database/sqlite-database.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart';
 import 'package:pocket_guard/helpers/datetime-utility-functions.dart';
 import 'package:pocket_guard/models/category-type.dart';
 import 'package:pocket_guard/models/category.dart';
+import 'package:pocket_guard/models/category_factory.dart';
 import 'package:pocket_guard/models/record.dart';
 import 'package:pocket_guard/models/recurrent-record-pattern.dart';
 import 'package:pocket_guard/models/template.dart';
@@ -56,7 +57,7 @@ class SqliteDatabase implements DatabaseInterface {
     final db = (await database)!;
     List<Map> results = await db.query("categories");
     return List.generate(results.length, (i) {
-      return Category.fromMap(results[i] as Map<String, dynamic>);
+      return CategoryFactory.getOrCreate(results[i] as Map<String, dynamic>);
     });
   }
 
@@ -68,7 +69,7 @@ class SqliteDatabase implements DatabaseInterface {
         where: "name = ? AND category_type = ?",
         whereArgs: [categoryName, categoryType.index]);
     return results.isNotEmpty
-        ? Category.fromMap(results[0] as Map<String, dynamic>)
+        ? CategoryFactory.getOrCreate(results[0] as Map<String, dynamic>)
         : null;
   }
 
@@ -255,7 +256,7 @@ class SqliteDatabase implements DatabaseInterface {
     }
     var matching = List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return Record.fromMap(currentRowMap);
     });
     return (matching.isEmpty) ? null : matching.first;
@@ -282,7 +283,7 @@ class SqliteDatabase implements DatabaseInterface {
         """);
     return List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return Record.fromMap(currentRowMap);
     });
   }
@@ -407,7 +408,7 @@ class SqliteDatabase implements DatabaseInterface {
 
     final records = List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return Record.fromMap(currentRowMap);
     });
 
@@ -472,7 +473,7 @@ class SqliteDatabase implements DatabaseInterface {
     List<Map> results = await db.query("categories",
         where: "category_type = ?", whereArgs: [categoryType.index]);
     return List.generate(results.length, (i) {
-      return Category.fromMap(results[i] as Map<String, dynamic>);
+      return CategoryFactory.getOrCreate(results[i] as Map<String, dynamic>);
     });
   }
 
@@ -494,7 +495,7 @@ class SqliteDatabase implements DatabaseInterface {
         """);
     final allTemplates =  List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return Template.fromMap(currentRowMap);
     });
 
@@ -527,7 +528,7 @@ class SqliteDatabase implements DatabaseInterface {
 
     var results = List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return Record.fromMap(currentRowMap);
     });
 
@@ -589,7 +590,7 @@ class SqliteDatabase implements DatabaseInterface {
 
     var results = List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return RecurrentRecordPattern.fromMap(currentRowMap);
     });
 
@@ -608,7 +609,7 @@ class SqliteDatabase implements DatabaseInterface {
 
     var results = List.generate(maps.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return RecurrentRecordPattern.fromMap(currentRowMap);
     });
 
@@ -653,7 +654,7 @@ class SqliteDatabase implements DatabaseInterface {
 
     var results = List.generate(maps!.length, (i) {
       Map<String, dynamic> currentRowMap = Map<String, dynamic>.from(maps[i]);
-      currentRowMap["category"] = Category.fromMap(currentRowMap);
+      currentRowMap["category"] = CategoryFactory.getOrCreate(currentRowMap);
       return Record.fromMap(currentRowMap);
     });
 


### PR DESCRIPTION
This commit introduces a `CategoryFactory` to optimize category object creation and reduce memory usage by caching `Category` instances.

- **`lib/models/category_factory.dart`**:
  - Adds a new `CategoryFactory` with a `getOrCreate` method. This method uses a cache to return existing `Category` instances based on their name and type, creating new ones only when necessary.

- **`lib/services/database/sqlite-database.dart`**:
  - Replaces all direct instantiations of `Category.fromMap` with calls to `CategoryFactory.getOrCreate`. This ensures that category objects retrieved from the database are cached and reused throughout the application.

- **`lib/categories/notifiers/edit_category_provider.dart`**:
  - Updates the category cloning logic to use `CategoryFactory.getOrCreate` instead of `Category.fromMap`, maintaining consistency with the new caching strategy.

Took 32 minutes