### PR TITLE
Refactor SettingsItem and improve Settings page UI

### DIFF
--- a/lib/settings/settings-item.dart
+++ b/lib/settings/settings-item.dart
@@ -4,31 +4,36 @@ import 'package:pocket_guard/settings/style.dart';
 class SettingsItem extends StatelessWidget {
   final Icon icon;
   final String title;
-  final Function onPressed;
-
+  final Widget? titleWidget;
+  final VoidCallback onPressed;
   final String? subtitle;
   final Color? iconBackgroundColor;
 
-  SettingsItem(
-      {this.iconBackgroundColor,
-      required this.icon,
-      required this.title,
-      required this.onPressed,
-      this.subtitle});
+  const SettingsItem({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.onPressed,
+    this.titleWidget,
+    this.subtitle,
+    this.iconBackgroundColor,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return RawMaterialButton(
+    return InkWell(
+      onTap: onPressed,
       child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         leading: CircleAvatar(
-            backgroundColor:
-                iconBackgroundColor == null ? Colors.blue : iconBackgroundColor,
-            child: icon),
-        title: Text(title, style: titleTextStyle),
-        subtitle:
-            subtitle == null ? null : Text(subtitle!, style: subtitleTextStyle),
+          backgroundColor: iconBackgroundColor ?? Colors.blue,
+          child: icon,
+        ),
+        title: titleWidget ?? Text(title, style: titleTextStyle),
+        subtitle: subtitle != null
+            ? Text(subtitle!, style: subtitleTextStyle)
+            : null,
       ),
-      onPressed: onPressed as void Function()?,
     );
   }
 }

--- a/lib/settings/settings-page.dart
+++ b/lib/settings/settings-page.dart
@@ -16,7 +16,6 @@ import '../i18n.dart';
 import 'backup-page.dart';
 import 'customization-page.dart';
 
-
 // look here for how to store settings
 //https://flutter.dev/docs/cookbook/persistence/key-value
 //https://pub.dev/packages/shared_preferences
@@ -34,10 +33,11 @@ class TabSettings extends StatelessWidget {
             .addTrueButtonName("Yes".i18n)
             .addFalseButtonName("No".i18n);
     var ok = await showDialog(
-        context: context,
-        builder: (BuildContext context) {
-          return premiumDialog.build(context);
-        });
+      context: context,
+      builder: (BuildContext context) {
+        return premiumDialog.build(context);
+      },
+    );
     if (ok) {
       await database.deleteDatabase();
       AlertDialogBuilder resultDialog =
@@ -45,10 +45,11 @@ class TabSettings extends StatelessWidget {
               .addSubtitle("All the data has been deleted".i18n)
               .addTrueButtonName("OK");
       await showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return resultDialog.build(context);
-          });
+        context: context,
+        builder: (BuildContext context) {
+          return resultDialog.build(context);
+        },
+      );
     }
   }
 
@@ -109,129 +110,129 @@ class TabSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-        child: Scaffold(
-      appBar: AppBar(
-        title: Text('Settings'.i18n),
-      ),
+    return Scaffold(
+      appBar: AppBar(title: Text('Settings'.i18n)),
       body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 10),
         children: <Widget>[
+          _buildSectionHeader(context, 'Appearance'.i18n),
           SettingsItem(
-              icon: Icon(
-                Icons.wallpaper,
-                color: Colors.white,
-              ),
-              iconBackgroundColor: Colors.blue.shade600,
-              title: 'Customization'.i18n,
-              subtitle: "Visual settings and more".i18n,
-              onPressed: () async => await goToCustomizationPage(context)),
-          Divider(),
+            icon: const Icon(Icons.wallpaper, color: Colors.white),
+            iconBackgroundColor: Colors.blue.shade600,
+            title: 'Customization'.i18n,
+            subtitle: "Visual settings and more".i18n,
+            onPressed: () => goToCustomizationPage(context),
+          ),
+
+          const Divider(),
+
+          _buildSectionHeader(context, 'Management'.i18n),
           SettingsItem(
-              icon: Icon(
-                Icons.repeat,
-                color: Colors.white,
-              ),
-              iconBackgroundColor: Colors.pink.shade600,
-              title: 'Recurrent Records'.i18n,
-              subtitle: "View or delete recurrent records".i18n,
-              onPressed: () async => await goToRecurrentRecordPage(context)),
-          SettingsItem(
-              icon: Icon(
-                Icons.tag,
-                color: Colors.white,
-              ),
-              iconBackgroundColor: Colors.amber.shade600,
-              title: 'Tags'.i18n,
-              subtitle: "Manage your existing tags".i18n,
-              onPressed: () async => await goToTagsPage(context)),
-          SettingsItem(
-              icon: Icon(
-                Icons.layers,
-                color: Colors.white,
-              ),
-              iconBackgroundColor: Colors.amber.shade600,
-              title: 'Templates'.i18n,
-              subtitle: "Manage your existing templates".i18n,
-              onPressed: () async => await goToTemplatesPage(context)),
-          Divider(),
-          SettingsItem(
-              icon: Icon(
-                Icons.backup,
-                color: Colors.white,
-              ),
-              iconBackgroundColor: Colors.orange.shade600,
-              title: 'Backup'.i18n,
-              subtitle: "Create backup and change settings".i18n,
-              onPressed: () async => await goToBackupPage(context)),
-          Stack(
-            children: [
-              SettingsItem(
-                icon: Icon(
-                  Icons.restore_page,
-                  color: Colors.white,
-                ),
-                iconBackgroundColor: Colors.teal,
-                title: 'Restore Backup'.i18n,
-                subtitle: "Restore data from a backup file".i18n,
-                onPressed: ServiceConfig.isPremium
-                    ? () async =>
-                        await BackupRestoreDialog.importFromBackupFile(context)
-                    : () async {
-                        await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => PremiumSplashScreen()),
-                        );
-                      },
-              ),
-              !ServiceConfig.isPremium
-                  ? Container(
-                      margin: EdgeInsets.fromLTRB(8, 8, 0, 0),
-                      child: getProLabel(labelFontSize: 10.0),
-                    )
-                  : Container()
-            ],
+            icon: const Icon(Icons.repeat, color: Colors.white),
+            iconBackgroundColor: Colors.pink.shade600,
+            title: 'Recurrent Records'.i18n,
+            subtitle: "View or delete recurrent records".i18n,
+            onPressed: () => goToRecurrentRecordPage(context),
           ),
           SettingsItem(
-            icon: Icon(
-              Icons.delete_outline,
-              color: Colors.white,
-            ),
-            iconBackgroundColor: Colors.teal,
+            icon: const Icon(Icons.tag, color: Colors.white),
+            iconBackgroundColor: Colors.amber.shade600,
+            title: 'Tags'.i18n,
+            subtitle: "Manage your existing tags".i18n,
+            onPressed: () => goToTagsPage(context),
+          ),
+          SettingsItem(
+            icon: const Icon(Icons.layers, color: Colors.white),
+            iconBackgroundColor: Colors.amber.shade600,
+            title: 'Templates'.i18n,
+            subtitle: "Manage your existing templates".i18n,
+            onPressed: () => goToTemplatesPage(context),
+          ),
+
+          const Divider(),
+
+          _buildSectionHeader(context, 'Data'.i18n),
+          SettingsItem(
+            icon: const Icon(Icons.backup, color: Colors.white),
+            iconBackgroundColor: Colors.orange.shade600,
+            title: 'Backup'.i18n,
+            subtitle: "Create backup and change settings".i18n,
+            onPressed: () => goToBackupPage(context),
+          ),
+
+          _buildRestoreBackupItem(context),
+
+          SettingsItem(
+            icon: const Icon(Icons.delete_outline, color: Colors.white),
+            iconBackgroundColor: Colors.red.shade400,
             title: 'Delete'.i18n,
             subtitle: 'Delete all the data'.i18n,
-            onPressed: () async => await deleteAllData(context),
+            onPressed: () => deleteAllData(context),
           ),
-          Divider(),
+
+          const Divider(),
+
+          _buildSectionHeader(context, 'Support'.i18n),
           SettingsItem(
-            icon: Icon(
-              Icons.info_outline,
-              color: Colors.white,
-            ),
+            icon: const Icon(Icons.info_outline, color: Colors.white),
             iconBackgroundColor: Colors.tealAccent.shade700,
             title: 'Info'.i18n,
             subtitle: 'Privacy policy and credits'.i18n,
-            onPressed: () async => await _launchURL(
-              //todo
-                ""),
+            onPressed: () => _launchURL(""),
           ),
           SettingsItem(
-            icon: Icon(
-              Icons.mail_outline,
-              color: Colors.white,
-            ),
+            icon: const Icon(Icons.mail_outline, color: Colors.white),
             iconBackgroundColor: Colors.red.shade700,
             title: 'Feedback'.i18n,
             subtitle: "Send us a feedback".i18n,
-            onPressed: () async {
-              await Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => FeedbackPage()),
-              );
-            },
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => FeedbackPage()),
+            ),
           ),
         ],
       ),
-    ));
+    );
+  }
+
+  Widget _buildRestoreBackupItem(BuildContext context) {
+    final bool isPremium = ServiceConfig.isPremium;
+
+    return SettingsItem(
+      icon: const Icon(Icons.restore_page, color: Colors.white),
+      iconBackgroundColor: Colors.teal,
+      titleWidget: Row(
+        children: [
+          Text('Restore Backup'.i18n),
+          if (!isPremium) ...[
+            const SizedBox(width: 8),
+            getProLabel(labelFontSize: 10.0),
+          ],
+        ],
+      ),
+      title: 'Restore Backup'.i18n,
+      subtitle: "Restore data from a backup file".i18n,
+      onPressed: isPremium
+          ? () => BackupRestoreDialog.importFromBackupFile(context)
+          : () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => PremiumSplashScreen()),
+            ),
+    );
+  }
+
+  Widget _buildSectionHeader(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Text(
+        title.toUpperCase(),
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.primary.withOpacity(0.7),
+          letterSpacing: 1.1,
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
This commit refactors the `SettingsItem` widget and enhances the structure and appearance of the Settings page.

- **`SettingsItem` Widget (`lib/settings/settings-item.dart`)**:
  - Replaced `RawMaterialButton` with `InkWell` to provide standard Material ripple effects on tap.
  - Introduced an optional `titleWidget` property to allow for more complex title layouts, such as including a "Pro" label.
  - Changed `onPressed` from `Function` to `VoidCallback` for improved type safety.
  - Added `const` constructor for performance optimization.

- **Settings Page (`lib/settings/settings-page.dart`)**:
  - Reorganized the settings list into logical sections ('Appearance', 'Management', 'Data', 'Support') using styled headers.
  - Integrated the "Pro" label for the 'Restore Backup' feature directly into the `SettingsItem` using the new `titleWidget`, removing the previous `Stack`-based layout.
  - Cleaned up widget construction by removing an unnecessary `Container` and making navigation calls more concise.
  - Added vertical padding to the `ListView` for better spacing.

Took 20 minutes